### PR TITLE
Fix build with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.18)
 project(ECDSAUTIL C)
 set(ECDSAUTIL_VERSION 0.3.2)
 


### PR DESCRIPTION
CMake 4 dropped support for policies which were introduced before version 3.5. Trying to build uisng cmake 4 results in:

    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

Just increasing minimum version to 3.18 (from 2020-07-15) fixes this problem. This version is low enough to still support Debian bullseye or Ubuntu 22.04.

With this version increase, following policies are enabled

* 3.18
  - CMP0108: A target cannot link to itself through an alias.
  - CMP0107: An ALIAS target cannot overwrite another target.
  - CMP0106: The Documentation module is removed.
  - CMP0105: Device link step uses the link options.
  - CMP0104: CMAKE_CUDA_ARCHITECTURES now detected for NVCC, empty CUDA_ARCHITECTURES not allowed.
  - CMP0103: Multiple export() with same FILE without APPEND is not allowed.
* 3.17
  - CMP0102: mark_as_advanced() does nothing if a cache entry does not exist.
  - CMP0101: target_compile_options honors BEFORE keyword in all scopes.
  - CMP0100: Let AUTOMOC and AUTOUIC process .hh header files.
  - CMP0099: Link properties are transitive over private dependencies of static libraries.
  - CMP0098: FindFLEX runs flex in CMAKE_CURRENT_BINARY_DIR when executing.
* 3.16
  - CMP0097: ExternalProject_Add with GIT_SUBMODULES "" initializes no submodules.
  - CMP0096: project() preserves leading zeros in version components.
  - CMP0095: RPATH entries are properly escaped in the intermediary CMake install script.
* 3.15
  - CMP0094: FindPython3, FindPython2 and FindPython use LOCATION for lookup strategy.
  - CMP0093: FindBoost reports Boost_VERSION in x.y.z format.
  - CMP0092: MSVC warning flags are not in CMAKE_{C,CXX}_FLAGS by default.
  - CMP0091: MSVC runtime library flags are selected by an abstraction.
  - CMP0090: export(PACKAGE) does not populate package registry by default.
  - CMP0089: Compiler id for IBM Clang-based XL compilers is now XLClang.
* 3.14
  - CMP0088: FindBISON runs bison in CMAKE_CURRENT_BINARY_DIR when executing.
  - CMP0087: install(SCRIPT | CODE) supports generator expressions.
  - CMP0086: UseSWIG honors SWIG_MODULE_NAME via -module flag.
  - CMP0085: IN_LIST generator expression handles empty list items.
  - CMP0084: The FindQt module does not exist for find_package().
  - CMP0083: Add PIE options when linking executable.
  - CMP0082: Install rules from add_subdirectory() are interleaved with those in caller.
* 3.13
  - CMP0081: Relative paths not allowed in LINK_DIRECTORIES target property.
  - CMP0080: BundleUtilities cannot be included at configure time.
  - CMP0079: target_link_libraries allows use with targets in other directories.
  - CMP0078: UseSWIG generates standard target names.
  - CMP0077: option() honors normal variables.
  - CMP0076: target_sources() command converts relative paths to absolute.
* 3.12
  - CMP0075: Include file check macros honor CMAKE_REQUIRED_LIBRARIES.
  - CMP0074: find_package uses PackageName_ROOT variables.
  - CMP0073: Do not produce legacy _LIB_DEPENDS cache entries.
* 3.11
  - CMP0072: FindOpenGL prefers GLVND by default when available.
* 3.10
  - CMP0071: Let AUTOMOC and AUTOUIC process GENERATED files.
  - CMP0070: Define file(GENERATE) behavior for relative paths.
* 3.9
  - CMP0069: INTERPROCEDURAL_OPTIMIZATION is enforced when enabled.
  - CMP0068: RPATH settings on macOS do not affect install_name.
* 3.8
  - CMP0067: Honor language standard in try_compile() source-file signature.
* 3.7
  - CMP0066: Honor per-config flags in try_compile() source-file signature.
* 3.4
  - CMP0065: Do not add flags to export symbols from executables without the ENABLE_EXPORTS target property.
  - CMP0064: Support new TEST if() operator.
* 3.3
  - CMP0063: Honor visibility properties for all target types.
  - CMP0062: Disallow install() of export() result.
  - CMP0061: CTest does not by default tell make to ignore errors (-i).
  - CMP0060: Link libraries by full path even in implicit directories.
  - CMP0059: Do not treat DEFINITIONS as a built-in directory property.
  - CMP0058: Ninja requires custom command byproducts to be explicit.
  - CMP0057: Support new IN_LIST if() operator.
* 3.2
  - CMP0056: Honor link flags in try_compile() source-file signature.
  - CMP0055: Strict checking for break() command.
* 3.1
  - CMP0054: Only interpret if() arguments as variables or keywords when unquoted.
  - CMP0053: Simplify variable reference and escape sequence evaluation.
  - CMP0052: Reject source and build dirs in installed INTERFACE_INCLUDE_DIRECTORIES.
  - CMP0051: List TARGET_OBJECTS in SOURCES target property.
* 3.0
  - CMP0050: Disallow add_custom_command SOURCE signatures.
  - CMP0049: Do not expand variables in target source entries.
  - CMP0048: project() command manages VERSION variables.
  - CMP0047: Use QCC compiler id for the qcc drivers on QNX.
  - CMP0046: Error on non-existent dependency in add_dependencies.
  - CMP0045: Error on non-existent target in get_target_property.
  - CMP0044: Case sensitive Lang_COMPILER_ID generator expressions.
  - CMP0043: Ignore COMPILE_DEFINITIONS_Config properties.
  - CMP0042: MACOSX_RPATH is enabled by default.
  - CMP0041: Error on relative include with generator expression.
  - CMP0040: The target in the TARGET signature of add_custom_command() must exist.
  - CMP0039: Utility targets may not have link dependencies.
  - CMP0038: Targets may not link directly to themselves.
  - CMP0037: Target names should not be reserved and should match a validity pattern.
  - CMP0036: The build_name command should not be called.
  - CMP0035: The variable_requires command should not be called.
  - CMP0034: The utility_source command should not be called.
  - CMP0033: The export_library_dependencies command should not be called.
  - CMP0032: The output_required_files command should not be called.
  - CMP0031: The load_command command should not be called.
  - CMP0030: The use_mangled_mesa command should not be called.
  - CMP0029: The subdir_depends command should not be called.
  - CMP0028: Double colon in target name means ALIAS or IMPORTED target.
  - CMP0027: Conditionally linked imported targets with missing include directories.
  - CMP0026: Disallow use of the LOCATION target property.
  - CMP0025: Compiler id for Apple Clang is now AppleClang.
  - CMP0024: Disallow include export result.